### PR TITLE
Add tests to lago install script

### DIFF
--- a/automation/check-patch.mounts.el7
+++ b/automation/check-patch.mounts.el7
@@ -1,0 +1,2 @@
+/var/run/libvirt
+/var/lib/lago

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -1,0 +1,5 @@
+wget
+git
+lago
+grubby
+parallel

--- a/automation/check-patch.repos.el7
+++ b/automation/check-patch.repos.el7
@@ -1,0 +1,3 @@
+ovirt-ci-tools,http://resources.ovirt.org/repos/ci-tools/$distro
+lago,http://resources.ovirt.org/repos/lago/stable/0.0/rpm/$distro
+centos-qemu-ev,http://mirror.centos.org/centos/$releasever/virt/$basearch/kvm-common/

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -ex
+
+readonly INIT_FILE='automation/init-el73'
+readonly TESTS_PATH='/tmp'
+readonly TIMEOUT="$((10 * 60))"
+
+function set_params() {
+    ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232
+    export LIBGUESTFS_BACKEND=direct
+    mkdir -p "$PWD/exported-artifacts"
+}
+
+function start_env() {
+    lago init "$INIT_FILE"
+    lago start
+}
+
+function copy_test_to_vm() {
+    set -ex
+    local vm test_name tests_path
+    vm="$1"
+    test_name="$2"
+    tests_path="$3"
+    lago copy-to-vm "$vm" "$PWD/tests/$test_name" "$tests_path/$test_name"
+    lago copy-to-vm "$vm" "$PWD/install_scripts/install_lago.sh" \
+        "$tests_path/$test_name/install_lago.sh"
+    lago shell "$vm" -c "chmod +x $tests_path/$test_name/*.sh"
+}
+
+function run_tests() {
+    set -ex
+    local args vm tests_path tests
+    args=("$@")
+    # note: with bash > 4.3 we could use args[-1] in unset also.
+    tests_path=${args[-1]} && unset "args[${#args[@]} -1]"
+    vm=${args[-1]} && unset "args[${#args[@]} -1]"
+    tests=(${args[@]})
+    # TO-DO: figure out why here the exit code does not propagate,
+    # requiring the explicit '|| exit $?'.
+    for test in "${tests[@]}"; do
+        lago shell "$vm" -c "$tests_path/$test/run.sh |& \
+            tee -a /var/log/test_$test.log; \
+            exit ${PIPESTATUS[0]}" || exit $?
+    done
+}
+
+
+function get_vm_names() {
+    local vms
+    vms=$(lago --out-format=flat status |\
+        grep -E "^VMs/(.*)/status: running$" |\
+        awk -F'/' \{'print $2'\})
+    echo "$vms"
+}
+
+function cleanup() {
+    lago collect --output "$PWD/exported-artifacts/logs/test_logs"
+    cp "$PWD/.lago/current/logs/lago.log" "$PWD/exported-artifacts/logs/test_logs/lago.log"
+    lago destroy --yes
+}
+
+function main() {
+    local vms
+    set_params
+    start_env
+    trap "cleanup" EXIT
+
+    vms=($(get_vm_names))
+    tests=($(ls "$PWD/tests"))
+    export -f copy_test_to_vm
+    parallel --tagstring "{1}:copy_test:" --lb -k --halt now,fail=1 \
+        copy_test_to_vm ::: "${vms[@]}" ::: "${tests[@]}" ::: "$TESTS_PATH"
+    export -f run_tests
+    parallel --timeout "$TIMEOUT" --tagstring "{-2}:run_tests:" --lb -k \
+        --halt now,fail=1 \
+        run_tests "${tests[@]}" ::: "${vms[@]}" ::: "$TESTS_PATH"
+}
+
+main
+

--- a/automation/init-el73
+++ b/automation/init-el73
@@ -1,0 +1,38 @@
+domains:
+  vm-el73:
+    memory: 2048
+    service_provider: systemd
+    nics:
+      - net: lago
+    disks:
+      - template_name: el7.3-base
+        type: template
+        name: root
+        dev: vda
+        format: qcow2
+    artifacts:
+      - /var/log
+      - /home/custom_home/dummy_user/.lago/current/logs
+
+  vm-fc24:
+    memory: 2048
+    service_provider: systemd
+    nics:
+      - net: lago
+    disks:
+      - template_name: fc24-base
+        type: template
+        name: root
+        dev: vda
+        format: qcow2
+    artifacts:
+      - /var/log
+      - /home/custom_home/dummy_user/.lago/current/logs
+nets:
+  lago:
+    type: nat
+    dhcp:
+      start: 100
+      end: 254
+    management: true
+    dns_domain_name: lago.local

--- a/tests/001-install_lago/run.sh
+++ b/tests/001-install_lago/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
+readonly USERNAME="dummy_user"
+readonly CUSTOM_HOME="custom_home"
+readonly INSTALL_SCRIPT="$RUN_DIR/install_lago.sh"
+
+function setup_user() {
+    local username custom_home
+    username="$1"
+    custom_home="$2"
+    mkdir -p "/home/$custom_home"
+    useradd -d "/home/$custom_home/$username" "$username"
+    echo "$username ALL=(ALL) NOPASSWD:ALL" | (EDITOR="tee -a" visudo)
+}
+
+function main() {
+    setup_user "$USERNAME" "$CUSTOM_HOME" || exit $?
+    sudo su "$USERNAME" -l -c "sudo $INSTALL_SCRIPT --user $USERNAME" || exit $?
+}
+
+main "$@"

--- a/tests/002-start-vm/init-nested
+++ b/tests/002-start-vm/init-nested
@@ -1,0 +1,21 @@
+domains:
+  nested:
+    memory: 512
+    service_provider: systemd
+    nics:
+      - net: lago-nested
+    disks:
+      - template_name: el7.3-base
+        type: template
+        name: root
+        dev: vda
+        format: qcow2
+nets:
+  lago-nested:
+    gw: 192.168.22.1
+    type: nat
+    dhcp:
+      start: 100
+      end: 254
+    management: true
+    dns_domain_name: lago-nested.local

--- a/tests/002-start-vm/run.sh
+++ b/tests/002-start-vm/run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+
+readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
+readonly USERNAME="dummy_user"
+readonly INIT_FILE="$RUN_DIR/init-nested"
+
+function start_vm() {
+    local username
+    username="$1"
+    sudo su "$username" -l << EOF
+bash -ex << EOS
+export LIBGUESTFS_BACKEND=direct
+export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+lago init $INIT_FILE
+lago start
+lago shell nested -c 'hostname'
+EOS
+EOF
+}
+
+function main() {
+    start_vm "$USERNAME" || exit $?
+}
+
+main "$@"


### PR DESCRIPTION
Add 'check-patch' verification for 'install_lago.sh' script. 

How does it work? by using Lago to test... Lago :)

In L0(under the mock env), it starts up 2 VMs using lago, one el7 and fc24. Then it copies the tests to those VMs, and runs the tests in parallel(VM-wise). There are two tests:
A. ```tests/001-install-lago/```
1. Adds a custom user 'dummy_user' with sudo privileges, which has a custom home directory(/home/something/dummy_user). 
2. Executes under that user ``sudo ./install_lago.sh dummy_user --user dummy_user``

B. ```tests/002-start-vm/```
1. Runs(again under dummy_user) lago init && lago start with a el7.3 template.

So basically, what we are testing here is that 'install_lago.sh' works flawlessly on CentOS7/Fedora24. Note that 'nested' is not enabled by default on the el7.3 image, so it tests that too.

As the tests run in parallel, it is better to look at the ``exported-artifacts`` to see the logs. For example: 
http://jenkins.ovirt.org/job/lago-demo_master_github_check-patch-el7-x86_64/7/artifact/exported-artifacts/logs/test_logs/vm-el73/_var_log/test_001-install_lago.log

Not directly related, but interesting point - we need a way to expose an host filesystem to the guest. What happens now is that the el7.3 is being downloaded twice, in the nested level, while it simply exists on the host.. sshfs/nfs will not work here as it needs to be on the Jenkins slave(which uses mock, no systemd and friends).