### PR TITLE
Install 'lago-*' instead of 'python-lago-*'

### DIFF
--- a/install_scripts/install_lago.sh
+++ b/install_scripts/install_lago.sh
@@ -90,7 +90,7 @@ enable_nested() {
 
 install_lago() {
     echo "Installing lago"
-    yum install -y python-lago python-lago-ovirt
+    yum install -y lago lago-ovirt
 }
 
 add_lago_repo() {


### PR DESCRIPTION
Not sure why it was there.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>