### PR TITLE
Detect el7_[1-4] as el7

### DIFF
--- a/install_scripts/install_lago.sh
+++ b/install_scripts/install_lago.sh
@@ -99,7 +99,7 @@ add_lago_repo() {
     distro_str=$(rpm -E "%{?dist}") || exit_error "rpm command not found, only \
       RHEL/CentOS/Fedora are supported"
     echo "Detected distro is $distro_str"
-    if [[ $distro_str == ".el7" ]]; then
+    if [[ $distro_str =~ ^.el7(_[1-4])?$ ]]; then
         print_rhel_notes
         distro="el"
     elif [[ $distro_str == ".el7.centos" ]]; then


### PR DESCRIPTION
It was reported that sometimes the distro macro for el7 is reported as
el7_3, instead of el7. This contradicts Fedora packaging guideline, but
we still need it detected.

fixes: https://github.com/lago-project/lago-demo/issues/14

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>