### PR TITLE
install_lago: improve services handling

### DIFF
--- a/tests/004-check-services/run.sh
+++ b/tests/004-check-services/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+function check_services() {
+    systemctl is-active libvirtd
+    systemctl is-active firewalld
+}
+
+function main() {
+    check_services || exit $?
+}
+
+main "$@"


### PR DESCRIPTION
1. Check if 'virtlogd' exists, and only then enable it. In all, this is
a workaround to BZ 1290357. But, in earlier libvirt versions, such as
el7.2, virtlogd might not exists.

2. use 'systemctl restart' instead of 'start', to ensure they are
restarting.

3. Ensure firewalld is restarted, after ovirtlago is installed.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>