### PR TITLE
automation: escape PIPESTATUS

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -36,12 +36,10 @@ function run_tests() {
     tests_path=${args[-1]} && unset "args[${#args[@]} -1]"
     vm=${args[-1]} && unset "args[${#args[@]} -1]"
     tests=(${args[@]})
-    # TO-DO: figure out why here the exit code does not propagate,
-    # requiring the explicit '|| exit $?'.
     for test in "${tests[@]}"; do
         lago shell "$vm" -c "$tests_path/$test/run.sh |& \
             tee -a /var/log/test_$test.log; \
-            exit ${PIPESTATUS[0]}" || exit $?
+            exit \${PIPESTATUS[0]}"
     done
 }
 

--- a/tests/001-install_lago/run.sh
+++ b/tests/001-install_lago/run.sh
@@ -15,8 +15,8 @@ function setup_user() {
 }
 
 function main() {
-    setup_user "$USERNAME" "$CUSTOM_HOME" || exit $?
-    sudo su "$USERNAME" -l -c "sudo $INSTALL_SCRIPT --user $USERNAME" || exit $?
+    setup_user "$USERNAME" "$CUSTOM_HOME"
+    sudo su "$USERNAME" -l -c "sudo $INSTALL_SCRIPT --user $USERNAME"
 }
 
 main "$@"

--- a/tests/002-start-vm/run.sh
+++ b/tests/002-start-vm/run.sh
@@ -19,7 +19,7 @@ EOF
 }
 
 function main() {
-    start_vm "$USERNAME" || exit $?
+    start_vm "$USERNAME"
 }
 
 main "$@"

--- a/tests/003-check-sdk/run.sh
+++ b/tests/003-check-sdk/run.sh
@@ -14,7 +14,7 @@ EOF
 }
 
 function main() {
-    check_sdk4 "$USERNAME" || exit $?
+    check_sdk4 "$USERNAME"
 }
 
 main "$@"


### PR DESCRIPTION
A bug in the 'check-patch.sh' caused the scripts to always exit with 0.
Now that it is fixed removed all un-needed(and useless) exit
commands(we run with -ex anyways).

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>