### PR TITLE
install_lago: always reload KVM

### DIFF
--- a/install_scripts/install_lago.sh
+++ b/install_scripts/install_lago.sh
@@ -87,7 +87,13 @@ function check_nested() {
 function reload_kvm() {
     local mod
     mod="kvm-$1"
-    (modprobe -r "$mod" && modprobe "$mod") && return 0 || return 1
+    echo "Reloading kvm kernel module"
+    (modprobe -r "$mod" && \
+        modprobe -r "kvm" && \
+        modprobe "kvm" && \
+        modprobe "$mod" ) && \
+        return 0 || \
+        return 1
 }
 
 function enable_nested() {
@@ -193,6 +199,7 @@ function post_install_conf_for_lago() {
     usermod -a -G lago,qemu "$INSTALL_USER"
     usermod -a -G "$INSTALL_USER" qemu
     chmod g+x "$user_home"
+    reload_kvm "$(get_cpu_vendor)"
 }
 
 function enable_service() {


### PR DESCRIPTION
It looks like on rather rare cases, after installing libvirt, 'kvm'
group permissions aren't set properly, specifically they are not 'group::rw-'.
The solution(suggested in the BZ) was reloading the kvm kernel module after
installation. This resolved the issue on the reported machine(fresh el7.3 install).

So this commit ensures we always reload 'kvm' when running the
script(even if nested was already enabled). This does has the downside
that if the user had already any other kvm guests running, the script will
fail on reloading kvm.

I should say this issue is not easily replicated.

Relevant BZ: https://bugzilla.redhat.com/show_bug.cgi?id=950436

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>