### PR TITLE
automation: add separate disk for /var/lib/lago and copy images

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-readonly INIT_FILE='automation/lago-init'
+readonly INIT_FILE='automation/lago-init.yaml'
 readonly TESTS_PATH='/tmp'
 readonly TIMEOUT="$((10 * 60))"
 
@@ -12,9 +12,11 @@ function set_params() {
 }
 
 function start_env() {
-    lago init "$INIT_FILE"
-    lago start
+    lago --loglevel=debug --logdepth=5 init "$INIT_FILE"
+    lago start && trap "cleanup" EXIT
+    lago deploy
 }
+
 
 function copy_test_to_vm() {
     set -ex
@@ -62,7 +64,6 @@ function main() {
     local vms
     set_params
     start_env
-    trap "cleanup" EXIT
 
     vms=($(get_vm_names))
     tests=($(ls "$PWD/tests"))

--- a/automation/deploy.sh
+++ b/automation/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+mkfs.xfs /dev/sdb
+mkdir -p /var/lib/lago
+mount /dev/sdb /var/lib/lago

--- a/automation/lago-init.yaml
+++ b/automation/lago-init.yaml
@@ -8,11 +8,20 @@ domains:
       - template_name: el7.3-base
         type: template
         name: root
-        dev: vda
+        dev: sda
+        format: qcow2
+      - comment: /var/lib/lago
+        size: 10G
+        type: empty
+        name: lib
+        dev: sdb
         format: qcow2
     artifacts:
       - /var/log
       - /home/custom_home/dummy_user/.lago/current/logs
+    metadata:
+      deploy-scripts:
+        - $LAGO_INITFILE_PATH/deploy.sh
 
   vm-fc24:
     memory: 2048
@@ -23,11 +32,20 @@ domains:
       - template_name: fc24-base
         type: template
         name: root
-        dev: vda
+        dev: sda
+        format: qcow2
+      - comment: /var/lib/lago
+        size: 10G
+        type: empty
+        name: lib
+        dev: sdb
         format: qcow2
     artifacts:
       - /var/log
       - /home/custom_home/dummy_user/.lago/current/logs
+    metadata:
+      deploy-scripts:
+        - $LAGO_INITFILE_PATH/deploy.sh
 nets:
   lago:
     type: nat


### PR DESCRIPTION
1. Add a secondary device for /var/lib/lago on the test machine, as Lago
does not support extending the template disk.

~~2. Copy the images from the host into the VM. This can be potentially
faster than downloading them from templates.ovirt.org and avoid flooding
the logs. But, as 'scp' does not support sparse files, so the gain on
that aspect is little. Hopefully we will fix that on Lago
side(use SFTP instead which does support it).~~

3. Also renamed lago-init to 'lago-init.yaml'
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>