### PR TITLE
install_lago: allow only configuring permissions for a user

### DIFF
--- a/tests/001-install_lago/run.sh
+++ b/tests/001-install_lago/run.sh
@@ -2,6 +2,7 @@
 
 readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
 readonly USERNAME="dummy_user"
+readonly SECONDARY_USER="dummy_user2"
 readonly CUSTOM_HOME="custom_home"
 readonly INSTALL_SCRIPT="$RUN_DIR/install_lago.sh"
 
@@ -16,7 +17,10 @@ function setup_user() {
 
 function main() {
     setup_user "$USERNAME" "$CUSTOM_HOME"
+    setup_user "$SECONDARY_USER" "$CUSTOM_HOME"
     sudo su "$USERNAME" -l -c "sudo bash -ex $INSTALL_SCRIPT --user $USERNAME"
+    sudo su "$SECONDARY_USER" -l -c \
+        "sudo bash -ex $INSTALL_SCRIPT -p --user $SECONDARY_USER"
 }
 
 main "$@"

--- a/tests/003-start-vm/run.sh
+++ b/tests/003-start-vm/run.sh
@@ -2,6 +2,7 @@
 
 readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
 readonly USERNAME="dummy_user"
+readonly SECONDARY_USER="dummy_user2"
 readonly INIT_FILE="$RUN_DIR/init-nested"
 
 function start_vm() {
@@ -13,13 +14,15 @@ export LIBGUESTFS_BACKEND=direct
 export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 lago init $INIT_FILE
 lago start
-lago shell nested -c 'hostname'
+lago shell nested -c 'hostname' && lago destroy --yes
+
 EOS
 EOF
 }
 
 function main() {
     start_vm "$USERNAME"
+    start_vm "$SECONDARY_USER"
 }
 
 main "$@"


### PR DESCRIPTION
Add the '-p' option which will only configure the needed permissions for
the user. This must be called after Lago is installed.

Example:

sudo ./install_lago.sh --user user1

... some time afterwards ...

sudo ./install_lago.sh --user user2 -p

Will allow 'user2' to run Lago as well.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>