### PR TITLE
tests: test upgrading from unstable repo to stable

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -2,7 +2,7 @@
 
 readonly INIT_FILE='automation/lago-init.yaml'
 readonly TESTS_PATH='/tmp'
-readonly TIMEOUT="$((10 * 60))"
+readonly TIMEOUT="$((17 * 60))"
 
 function set_params() {
     ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232

--- a/tests/004-upgrade-to-unstable/init-nested
+++ b/tests/004-upgrade-to-unstable/init-nested
@@ -1,0 +1,1 @@
+../003-start-vm/init-nested

--- a/tests/004-upgrade-to-unstable/run.sh
+++ b/tests/004-upgrade-to-unstable/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -ex
+
+readonly RUN_DIR="$(dirname "${BASH_SOURCE[0]}")"
+readonly USERNAME="dummy_user"
+readonly SECONDARY_USER="dummy_user2"
+readonly INIT_FILE="$RUN_DIR/init-nested"
+
+function start_vm() {
+    local username
+    username="$1"
+    sudo su "$username" -l << EOF
+bash -ex << EOS
+export LIBGUESTFS_BACKEND=direct
+export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+lago --version
+lago ovirt --help
+lago init $INIT_FILE
+lago start
+lago shell nested -c 'hostname' && lago destroy --yes
+
+EOS
+EOF
+}
+
+function switch_unstable {
+    local dist_type
+    dist_type=$(/usr/lib/rpm/redhat/dist.sh  --disttype)
+    cat >> /etc/yum.repos.d/lago-unstable.repo << EOF
+[lago-unstable]
+baseurl=http://resources.ovirt.org/repos/lago/unstable/0.0/latest/rpm/$dist_type\$releasever
+name=Lago
+enabled=1
+gpgcheck=0
+EOF
+    rm -rf /etc/yum.repos.d/lago.repo
+    yum clean all
+    }
+
+function update_lago
+{
+
+    rpm -q lago
+    rpm -q lago-ovirt
+    lago --version
+    yum update -y lago lago-ovirt
+    lago --version
+    rpm -q lago
+    rpm -q lago-ovirt
+}
+
+
+function main() {
+    switch_unstable
+    update_lago
+    start_vm "$USERNAME"
+    start_vm "$SECONDARY_USER"
+}
+
+main "$@"


### PR DESCRIPTION
A new test which upgrades lago and lago-ovirt to the version found at lago's unstable version and starts the VM again.
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>