### PR TITLE
Configure IPv6 ra and test installation on el7.4

### DIFF
--- a/automation/lago-init.yaml
+++ b/automation/lago-init.yaml
@@ -1,11 +1,11 @@
 domains:
-  vm-el73:
+  vm-el74:
     memory: 2048
     service_provider: systemd
     nics:
       - net: lago
     disks:
-      - template_name: el7.3-base
+      - template_name: el7.4-base
         type: template
         name: root
         dev: sda

--- a/install_scripts/install_lago.sh
+++ b/install_scripts/install_lago.sh
@@ -217,6 +217,10 @@ function enable_services() {
         enable_service "virtlogd"
 }
 
+function configure_ipv6_networking() {
+    echo "net.ipv6.conf.all.accept_ra=2" >> "/etc/sysctl.conf"
+    sysctl -p
+}
 
 function run_suite() {
     sudo -u "$INSTALL_USER" bash <<EOF
@@ -353,6 +357,7 @@ function main() {
     post_install_conf_for_lago
     reload_kvm "$(get_cpu_vendor)"
     enable_services
+    configure_ipv6_networking
     echo "Finished installing and configuring Lago for user $INSTALL_USER."
     run_suite
 }


### PR DESCRIPTION
1. In the install script, configure accept_ra=2.
   This is needed by latest versions of libvirt in order to run 
   IPv6 enabled networks.

2. Test lago on Centos 7.4 (this also verifies 1).

Signed-off-by: gbenhaim <galbh2@gmail.com>