### PR TITLE
tests: Make "nested_vm_template" variable global

### DIFF
--- a/roles/run_lago_env/defaults/main.yaml
+++ b/roles/run_lago_env/defaults/main.yaml
@@ -1,2 +1,1 @@
-nested_vm_template: el7.4-base
 remote_init_dir: /tmp

--- a/vars.yaml
+++ b/vars.yaml
@@ -3,3 +3,4 @@ secondary_user: dummy_user2
 run_path: "/tmp"
 log_path: "/var/log"
 template_repo: "http://templates.ovirt.org/repo/repo.metadata"
+nested_vm_template: el7.4-base


### PR DESCRIPTION
This variable is being used by two roles: "run_lago_env" and "upgrade",
thus it should be visible to both of them.

Signed-off-by: gbenhaim <galbh2@gmail.com>