### PR TITLE
Adding support for fc27

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -51,7 +51,7 @@ force_cleanup() {
 
 function main() {
     set_params
-    start_env && trap "cleanup" EXIT
+    start_env
     ansible-playbook \
         -u root \
         -i inventory \
@@ -59,4 +59,5 @@ function main() {
         test-playbook.yaml
 }
 
+trap "cleanup" EXIT
 main

--- a/automation/lago-init.yaml
+++ b/automation/lago-init.yaml
@@ -1,75 +1,63 @@
+common_vm_params: &common_vm_params
+  memory: 2048
+  service_provider: systemd
+  nics:
+    - net: lago
+  artifacts:
+    - /var/log
+    - /home/custom_home/dummy_user/.lago/current/logs
+  metadata:
+    deploy-scripts:
+      - $LAGO_INITFILE_PATH/deploy.sh
+
+storage_disk: &storage_disk
+  comment: /var/lib/lago
+  size: 10G
+  type: empty
+  name: lib
+  dev: sdb
+  format: qcow2
+
 domains:
   lago-vm-el74:
-    memory: 2048
-    service_provider: systemd
-    nics:
-      - net: lago
+    <<: *common_vm_params
     disks:
       - template_name: el7.4-base
         type: template
         name: root
         dev: sda
         format: qcow2
-      - comment: /var/lib/lago
-        size: 10G
-        type: empty
-        name: lib
-        dev: sdb
-        format: qcow2
-    artifacts:
-      - /var/log
-      - /home/custom_home/dummy_user/.lago/current/logs
-    metadata:
-      deploy-scripts:
-        - $LAGO_INITFILE_PATH/deploy.sh
+      - *storage_disk
 
   lago-vm-fc25:
-    memory: 2048
-    service_provider: systemd
-    nics:
-      - net: lago
+    <<: *common_vm_params
     disks:
       - template_name: fc25-base
         type: template
         name: root
         dev: sda
         format: qcow2
-      - comment: /var/lib/lago
-        size: 10G
-        type: empty
-        name: lib
-        dev: sdb
-        format: qcow2
-    artifacts:
-      - /var/log
-      - /home/custom_home/dummy_user/.lago/current/logs
-    metadata:
-      deploy-scripts:
-        - $LAGO_INITFILE_PATH/deploy.sh
+      - *storage_disk
 
   lago-vm-fc26:
-    memory: 2048
-    service_provider: systemd
-    nics:
-      - net: lago
+    <<: *common_vm_params
     disks:
       - template_name: fc26-base
         type: template
         name: root
         dev: sda
         format: qcow2
-      - comment: /var/lib/lago
-        size: 10G
-        type: empty
-        name: lib
-        dev: sdb
+      - *storage_disk
+
+  lago-vm-fc27:
+    <<: *common_vm_params
+    disks:
+      - template_name: fc27-base
+        type: template
+        name: root
+        dev: sda
         format: qcow2
-    artifacts:
-      - /var/log
-      - /home/custom_home/dummy_user/.lago/current/logs
-    metadata:
-      deploy-scripts:
-        - $LAGO_INITFILE_PATH/deploy.sh
+      - *storage_disk
 nets:
   lago:
     type: nat

--- a/install_scripts/install_lago.sh
+++ b/install_scripts/install_lago.sh
@@ -15,6 +15,8 @@ readonly RHEL_CHANNELS=(
 'rhel-7-server-rhv-4-mgmt-agent-rpms'
 )
 
+readonly SUPPORTED_DISTROS="fc25, fc26, fc27, el7"
+readonly FEDORA_RGX="^.fc2[567]$"
 
 if hash dnf &>/dev/null; then
     readonly PKG_MG="dnf"
@@ -178,15 +180,11 @@ function add_repos() {
         "$PKG_MG" install -y epel-release
         "$PKG_MG" install -y centos-release-qemu-ev
         add_ovirt_repo "$distro"
-    elif [[ $distro_str =~ ^.fc2[456]$ ]]; then
+    elif [[ $distro_str =~ $FEDORA_RGX ]]; then
         distro="fc"
-        # ovirt python sdk is not available on fc25/26
-        if [[ $distro_str == ".fc24" ]]; then
-            add_ovirt_repo "$distro"
-        fi
     else
         exit_error "Unsupported distro: $distro_str, Supported distros: \
-            fc24, fc25, fc26, el7."
+            ${SUPPORTED_DISTROS}"
     fi
     add_lago_repo "$distro"
 }
@@ -252,7 +250,7 @@ function print_help() {
 Usage: $0
 $0 [options]
 
-Lago and Lago-ovirt installation script, supported distros: el7/fc24/fc25
+Lago and Lago-ovirt installation script, supported distros: ${SUPPORTED_DISTROS}
 
 Optionally, you can pass a '--suite' parameter, and it will also download and
 execute one of the available oVirt system tests suites.
@@ -351,7 +349,7 @@ function main() {
     distro_str="$(detect_distro)"
     add_repos "$distro_str"
     install_lago
-    if ! [[ "$distro_str" =~ ^.fc2[56]$ ]]; then
+    if ! [[ "$distro_str" =~ $FEDORA_RGX ]]; then
         install_ovirt_sdk
     fi
     post_install_conf_for_lago

--- a/roles/lago_host/tasks/main.yaml
+++ b/roles/lago_host/tasks/main.yaml
@@ -1,3 +1,8 @@
+- name: Run system update
+  package:
+    name: '*'
+    state: latest
+
 - name: Make sure 'wheel' group exist
   group:
     name: wheel

--- a/roles/verify_install/defaults/main.yaml
+++ b/roles/verify_install/defaults/main.yaml
@@ -1,3 +1,4 @@
 skip_sdk_v4_verification:
   Fedora-25
   Fedora-26
+  Fedora-27


### PR DESCRIPTION
1. Adding support for fc27.
2. Making LagoInitFile more compact.
3. Hold supported distros string in a variable.
4. Remove unneeded code which relates to fc24.

Signed-off-by: gbenhaim <galbh2@gmail.com>